### PR TITLE
Fix bug with exclude-dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "souper"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "souper"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/dir_scan.rs
+++ b/src/dir_scan.rs
@@ -20,7 +20,7 @@ pub fn scan(dir: &path::PathBuf, exclude_dirs: &Vec<path::PathBuf>) -> Result<Ve
                 }
             }
             for ex in exclude_dirs {
-                if file_name.eq(ex) {
+                if path.eq(ex) {
                     continue 'entries;
                 }
             }


### PR DESCRIPTION
Since we get a complete path we must compare with a path (not a file name)