### PR TITLE
Default meta key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.2.8", features = ["derive"] }
 serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.82"
+serde_json = { version = "1.0.82", features = ["preserve_order"] }
 quick-xml = "0.23.0"
 regex = "1.6.0"
 lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Scans a given directory for [software of unknown provinence (SOUP)](https://en.wikipedia.org/wiki/Software_of_unknown_pedigree) and writes them to a json-file.
 The json-file contains name, version and a meta property for each SOUP.
-The meta property may be populated with arbitrary metadata.
-If you run souper after the version of a SOUP has been updated, the json-file will be updated with the new version, while preserving the arbitrary metadata.
+The meta property is a json object which may be populated with arbitrary metadata.
+If you run souper after the version of a SOUP has been updated, the json-file will be updated with the new version, while preserving content of the meta property.
 If a SOUP has been added or removed, the json-file will be updated accordingly.
 
 *Why*? 
@@ -47,6 +47,18 @@ Navigate to to the repository where you'd like to run souper.
 Alternatively, you can run souper from any directory:
 
 `souper --directory /path/to/my/repo --output-file soups.json`
+
+### Excluding directories
+
+In case there's a directory that you'd like to skip, use the `--exclude-directory` argument.
+
+`souper --output-file soups.json --exclude-directory ./test/`
+
+### Default meta keys
+
+If you know what properties that you'd like in the meta property, you can have them created automatically by using the `--meta-key` argument.
+
+`souper --output-file soups.json --meta-key requirements --meta-key manufacturer`
 
 ## Create a release
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,6 @@ fn main() {
             panic!("Failed to parse --meta-key");
         }
     };
-    println!("{:?}", default_meta);
 
     let current_contexts = match output_path.is_file() {
         true => match SoupContexts::from_output_file(&output_path) {
@@ -81,7 +80,7 @@ fn main() {
             panic!("{}", e);
         }
     };
-    let scanned_contexts = match SoupContexts::from_paths(result, path) {
+    let scanned_contexts = match SoupContexts::from_paths(result, path, default_meta) {
         Ok(contexts) => contexts,
         Err(e) => {
             panic!("{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use std::{
+    collections::HashMap,
     env,
     path
 };
+use serde_json::json;
 use clap::Parser;
 
 mod soup;
@@ -25,7 +27,11 @@ struct Cli {
 
     /// Directory to exclude
     #[clap(short = 'e', long = "exclude-directory", parse(from_os_str))]
-    exclude_dirs: Vec<path::PathBuf>
+    exclude_dirs: Vec<path::PathBuf>,
+
+    // Key to add in meta property
+    #[clap(short = 'm', long = "meta-key")]
+    meta_keys: Vec<String>
 }
 
 fn main() {
@@ -48,6 +54,17 @@ fn main() {
         panic!("Invalid output file: {:?}", output_path);
     }
     let exclude_dirs = args.exclude_dirs;
+
+    let default_meta = serde_json::to_value(args.meta_keys.into_iter()
+        .map(|meta_key| (meta_key, json!("")))
+        .collect::<HashMap<String, serde_json::Value>>());
+    let default_meta = match default_meta {
+        Ok(meta) => meta,
+        Err(_e) => {
+            panic!("Failed to parse --meta-key");
+        }
+    };
+    println!("{:?}", default_meta);
 
     let current_contexts = match output_path.is_file() {
         true => match SoupContexts::from_output_file(&output_path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
 use std::{
-    collections::HashMap,
     env,
     path
 };
-use serde_json::json;
+use serde_json::{
+    json,
+    Map,
+    Value
+};
 use clap::Parser;
 
 mod soup;
@@ -55,15 +58,9 @@ fn main() {
     }
     let exclude_dirs = args.exclude_dirs;
 
-    let default_meta = serde_json::to_value(args.meta_keys.into_iter()
+    let default_meta = args.meta_keys.into_iter()
         .map(|meta_key| (meta_key, json!("")))
-        .collect::<HashMap<String, serde_json::Value>>());
-    let default_meta = match default_meta {
-        Ok(meta) => meta,
-        Err(_e) => {
-            panic!("Failed to parse --meta-key");
-        }
-    };
+        .collect::<Map<String, Value>>();
 
     let current_contexts = match output_path.is_file() {
         true => match SoupContexts::from_output_file(&output_path) {

--- a/src/parse/csproj.rs
+++ b/src/parse/csproj.rs
@@ -4,7 +4,6 @@ use std::{
 };
 use quick_xml::events::Event;
 use quick_xml::Reader;
-use serde_json::json;
 use super::SoupSource;
 use crate::soup::model::{Soup, SoupSourceParseError};
 
@@ -14,7 +13,7 @@ impl<R> SoupSource<R> for CsProj
 where
     R: io::BufRead,
 {
-    fn soups(reader: R) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
+    fn soups(reader: R, default_meta: &serde_json::Value) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
         let mut reader = Reader::from_reader(reader);
         reader.trim_text(true);
         reader.expand_empty_elements(true);
@@ -33,7 +32,7 @@ where
                         soups.insert(Soup {
                             name,
                             version,
-                            meta: json!({})
+                            meta: default_meta.clone()
                         });
                 },
                 Ok(Event::Eof) => break,
@@ -83,7 +82,7 @@ mod tests {
 </Project>
         "#.as_bytes();
 
-        let result = CsProj::soups(content);
+        let result = CsProj::soups(content, &json!({}));
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(1, soups.len());
@@ -106,7 +105,7 @@ mod tests {
 </Project>
         "#.as_bytes();
 
-        let result = CsProj::soups(content);
+        let result = CsProj::soups(content, &json!({}));
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(2, soups.len());
@@ -126,7 +125,7 @@ mod tests {
 </Project>
         "#.as_bytes();
 
-        let result = CsProj::soups(content);
+        let result = CsProj::soups(content, &json!({}));
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(0, soups.len());

--- a/src/parse/csproj.rs
+++ b/src/parse/csproj.rs
@@ -2,6 +2,10 @@ use std::{
     collections::{BTreeSet, HashMap},
     io
 };
+use serde_json::{
+    Map,
+    Value
+};
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use super::SoupSource;
@@ -13,7 +17,7 @@ impl<R> SoupSource<R> for CsProj
 where
     R: io::BufRead,
 {
-    fn soups(reader: R, default_meta: &serde_json::Value) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
+    fn soups(reader: R, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
         let mut reader = Reader::from_reader(reader);
         reader.trim_text(true);
         reader.expand_empty_elements(true);
@@ -70,7 +74,6 @@ fn attribute_value(attributes: &HashMap<Vec<u8>, Vec<u8>>, key: &str) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn single_dependency() {
@@ -82,14 +85,14 @@ mod tests {
 </Project>
         "#.as_bytes();
 
-        let result = CsProj::soups(content, &json!({}));
+        let result = CsProj::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(1, soups.len());
         let expected_soup = Soup {
             name: "Azure.Messaging.ServiceBus".to_owned(),
             version: "7.2.1".to_owned(),
-            meta: json!({}),
+            meta: Map::new()
         };
         assert_eq!(true, soups.contains(&expected_soup));
     }
@@ -105,13 +108,13 @@ mod tests {
 </Project>
         "#.as_bytes();
 
-        let result = CsProj::soups(content, &json!({}));
+        let result = CsProj::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(2, soups.len());
         let expected_soups = vec![
-            Soup { name: "Azure.Messaging.ServiceBus".to_owned(), version: "7.2.1".to_owned(), meta: json!({}) },
-            Soup { name: "Swashbuckle.AspNetCore".to_owned(), version: "6.3.1".to_owned(), meta: json!({}) }
+            Soup { name: "Azure.Messaging.ServiceBus".to_owned(), version: "7.2.1".to_owned(), meta: Map::new() },
+            Soup { name: "Swashbuckle.AspNetCore".to_owned(), version: "6.3.1".to_owned(), meta: Map::new() }
         ].into_iter().collect::<BTreeSet<Soup>>();
         assert_eq!(expected_soups, soups);
     }
@@ -125,7 +128,7 @@ mod tests {
 </Project>
         "#.as_bytes();
 
-        let result = CsProj::soups(content, &json!({}));
+        let result = CsProj::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(0, soups.len());

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,10 +1,13 @@
 use std::collections::BTreeSet;
 use std::io;
-use serde_json;
+use serde_json::{
+    Map,
+    Value
+};
 use crate::soup::model::{Soup, SoupSourceParseError};
 
 pub trait SoupSource<R: io::BufRead> {
-    fn soups(reader: R, default_meta: &serde_json::Value) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
+    fn soups(reader: R, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
 }
 
 pub mod package_json;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeSet;
 use std::io;
+use serde_json;
 use crate::soup::model::{Soup, SoupSourceParseError};
 
 pub trait SoupSource<R: io::BufRead> {
-    fn soups(reader: R) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
+    fn soups(reader: R, default_meta: &serde_json::Value) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
 }
 
 pub mod package_json;

--- a/src/soup/contexts_combine.rs
+++ b/src/soup/contexts_combine.rs
@@ -135,4 +135,6 @@ mod tests {
         assert_eq!("1.2.0", soup.version);
         assert_eq!(json!("{\"some-meta\": \"some-value\"}"), soup.meta);
     }
+
+    // TODO: Add tests for default_meta
 }

--- a/src/soup/contexts_combine.rs
+++ b/src/soup/contexts_combine.rs
@@ -142,22 +142,22 @@ mod tests {
         assert_eq!(*json!({"some-meta": "some-value"}).as_object().unwrap(), soup.meta);
     }
 
-    //#[test]
-    //fn update_with_new_meta_keys() {
-        //let first = create_contexts("src/package.json", vec![
-            //Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: json!({"some-meta": "some-value"}) }
-        //]);
-        //let second = create_contexts("src/package.json", vec![
-            //Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: json!({"requirements": ""}) }
-        //]);
-        //let result = SoupContexts::combine(first, second);
-        //assert_eq!(1, result.contexts.len());
-        //let soups = result.contexts.get("src/package.json").unwrap();
-        //let soup = soups.iter().find(|s| s.name == "some-dep").unwrap();
-        //assert_eq!("some-dep", soup.name);
-        //assert_eq!("1.0.0", soup.version);
-        //assert_eq!(json!({"some-meta": "some-value", "requirements": ""}), soup.meta);
-    //}
+    #[test]
+    fn update_with_new_meta_keys() {
+        let first = create_contexts("src/package.json", vec![
+            Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: json!({"some-meta": "some-value"}).as_object().unwrap().clone() }
+        ]);
+        let second = create_contexts("src/package.json", vec![
+            Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: json!({"requirements": ""}).as_object().unwrap().clone() }
+        ]);
+        let result = SoupContexts::combine(first, second);
+        assert_eq!(1, result.contexts.len());
+        let soups = result.contexts.get("src/package.json").unwrap();
+        let soup = soups.iter().find(|s| s.name == "some-dep").unwrap();
+        assert_eq!("some-dep", soup.name);
+        assert_eq!("1.0.0", soup.version);
+        assert_eq!(json!({"some-meta": "some-value", "requirements": ""}).as_object().unwrap().clone(), soup.meta);
+    }
 
     // TODO: Add tests for default_meta
 }

--- a/src/soup/contexts_combine.rs
+++ b/src/soup/contexts_combine.rs
@@ -4,11 +4,6 @@ use crate::soup::model::{Soup, SoupContexts};
 
 impl SoupContexts {
     pub fn combine(base: SoupContexts, other: SoupContexts) -> SoupContexts {
-        if base.contexts == other.contexts {
-            return SoupContexts {
-                contexts: base.contexts,
-            };
-        }
         let mut result_contexts = base.contexts.clone();
         other.contexts.iter()
             .filter(|(path, _soups)| !base.contexts.contains_key(*path))
@@ -29,7 +24,7 @@ impl SoupContexts {
                     name: soup.name.clone(),
                     version: soup.version.clone(),
                     meta: match meta_by_name.get(&soup.name) {
-                        Some(meta) => (*meta).clone(),
+                        Some(meta) => combine_meta(*meta, &soup.meta),
                         None => soup.meta.clone(),
                     }
                 })
@@ -44,8 +39,14 @@ impl SoupContexts {
 
 
 // TODO: Update meta to be a JSON object (not arbitrary value)
-fn combine_meta(m1: &Value, m2: &Value) -> Value {
-    serde_json::to_value("").unwrap()
+fn combine_meta(base: &Map<String, Value>, patch: &Map<String, Value>) -> Map<String, Value> {
+    let mut result = base.clone();
+    for (key, value) in patch {
+        if !base.contains_key(key) {
+            result.insert(key.clone(), value.clone());
+        }
+    }
+    result
 }
 
 #[cfg(test)]

--- a/src/soup/contexts_combine.rs
+++ b/src/soup/contexts_combine.rs
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn update_with_new_meta_keys() {
+    fn update_with_meta_keys() {
         let first = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: json!({"some-meta": "some-value"}).as_object().unwrap().clone() }
         ]);
@@ -158,6 +158,24 @@ mod tests {
         assert_eq!("some-dep", soup.name);
         assert_eq!("1.0.0", soup.version);
         assert_eq!(json!({"some-meta": "some-value", "requirements": ""}).as_object().unwrap().clone(), soup.meta);
+    }
+
+    #[test]
+    fn update_with_meta_keys_dont_overwrite() {
+        let first = create_contexts("src/package.json", vec![
+            Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: json!({"requirements": "a-requirement"}).as_object().unwrap().clone() }
+        ]);
+        let second = create_contexts("src/package.json", vec![
+            Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: json!({"requirements": ""}).as_object().unwrap().clone() }
+        ]);
+
+        let result = SoupContexts::combine(first, second);
+        assert_eq!(1, result.contexts.len());
+        let soups = result.contexts.get("src/package.json").unwrap();
+        let soup = soups.iter().find(|s| s.name == "some-dep").unwrap();
+        assert_eq!("some-dep", soup.name);
+        assert_eq!("1.0.0", soup.version);
+        assert_eq!(json!({"requirements": "a-requirement"}).as_object().unwrap().clone(), soup.meta);
     }
 
     // TODO: Add tests for default_meta

--- a/src/soup/contexts_combine.rs
+++ b/src/soup/contexts_combine.rs
@@ -76,38 +76,38 @@ mod tests {
 
     #[test]
     fn combine_add_context() {
-        let first = empty_contexts();
-        let second = create_contexts("src/package.json", vec![
+        let base = empty_contexts();
+        let other = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![]) }
         ]);
 
-        let result = SoupContexts::combine(first, second);
+        let result = SoupContexts::combine(base, other);
         assert_eq!(1, result.contexts.len());
         assert_eq!(true, result.contexts.contains_key("src/package.json"));
     }
 
     #[test]
     fn combine_remove_context() {
-        let first = create_contexts("src/package.json", vec![
+        let base = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![]) }
         ]);
-        let second = empty_contexts();
+        let other = empty_contexts();
 
-        let result = SoupContexts::combine(first, second);
+        let result = SoupContexts::combine(base, other);
         assert_eq!(true, result.contexts.is_empty());
     }
 
     #[test]
     fn combine_added_soup() {
-        let first = create_contexts("src/package.json", vec![
+        let base = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![]) }
         ]);
-        let second = create_contexts("src/package.json", vec![
+        let other = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![]) },
             Soup { name: "some-other-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![]) }
         ]);
         
-        let result = SoupContexts::combine(first, second);
+        let result = SoupContexts::combine(base, other);
         assert_eq!(1, result.contexts.len());
         let soups = result.contexts.get("src/package.json").unwrap();
         assert_eq!(2, soups.len());
@@ -115,15 +115,15 @@ mod tests {
 
     #[test]
     fn combine_removed_soup() {
-        let first = create_contexts("src/package.json", vec![
+        let base = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![]) },
             Soup { name: "some-other-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![]) }
         ]);
-        let second = create_contexts("src/package.json", vec![
+        let other = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![]) }
         ]);
         
-        let result = SoupContexts::combine(first, second);
+        let result = SoupContexts::combine(base, other);
         assert_eq!(1, result.contexts.len());
         let soups = result.contexts.get("src/package.json").unwrap();
         assert_eq!(1, soups.len());
@@ -131,14 +131,14 @@ mod tests {
 
     #[test]
     fn update_soup_version_preserves_meta() {
-        let first = create_contexts("src/package.json", vec![
+        let base = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![("some-meta", "some-value")]) }
         ]);
-        let second = create_contexts("src/package.json", vec![
+        let other = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.2.0".to_owned(), meta: meta(vec![]) }
         ]);
 
-        let result = SoupContexts::combine(first, second);
+        let result = SoupContexts::combine(base, other);
         assert_eq!(1, result.contexts.len());
         let soups = result.contexts.get("src/package.json").unwrap();
         let soup = soups.iter().find(|s| s.name == "some-dep").unwrap();
@@ -148,14 +148,14 @@ mod tests {
     }
 
     #[test]
-    fn update_with_meta_keys() {
-        let first = create_contexts("src/package.json", vec![
+    fn append_meta_from_other() {
+        let base = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![("some-meta", "some-value")]) }
         ]);
-        let second = create_contexts("src/package.json", vec![
+        let other = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![("requirements", "")]) }
         ]);
-        let result = SoupContexts::combine(first, second);
+        let result = SoupContexts::combine(base, other);
         assert_eq!(1, result.contexts.len());
         let soups = result.contexts.get("src/package.json").unwrap();
         let soup = soups.iter().find(|s| s.name == "some-dep").unwrap();
@@ -168,15 +168,15 @@ mod tests {
     }
 
     #[test]
-    fn update_with_meta_keys_dont_overwrite() {
-        let first = create_contexts("src/package.json", vec![
+    fn append_meta_from_other_no_overwrite() {
+        let base = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![("requirements", "a-requirement")]) }
         ]);
-        let second = create_contexts("src/package.json", vec![
+        let other = create_contexts("src/package.json", vec![
             Soup { name: "some-dep".to_owned(), version: "1.0.0".to_owned(), meta: meta(vec![("requirements", "")]) }
         ]);
 
-        let result = SoupContexts::combine(first, second);
+        let result = SoupContexts::combine(base, other);
         assert_eq!(1, result.contexts.len());
         let soups = result.contexts.get("src/package.json").unwrap();
         let soup = soups.iter().find(|s| s.name == "some-dep").unwrap();

--- a/src/soup/contexts_combine.rs
+++ b/src/soup/contexts_combine.rs
@@ -38,7 +38,6 @@ impl SoupContexts {
 }
 
 
-// TODO: Update meta to be a JSON object (not arbitrary value)
 fn combine_meta(base: &Map<String, Value>, patch: &Map<String, Value>) -> Map<String, Value> {
     let mut result = base.clone();
     for (key, value) in patch {

--- a/src/soup/contexts_io.rs
+++ b/src/soup/contexts_io.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{BufReader, Write};
 use std::path::{Path, PathBuf};
-use serde_json;
+use serde_json::{
+    Map,
+    Value
+};
 
 use crate::soup::model::{Soup, SoupContexts, SouperIoError};
 use crate::parse::{
@@ -17,7 +20,7 @@ impl SoupContexts {
     pub fn from_paths<P: AsRef<Path>>(
         paths: Vec<PathBuf>,
         source_dir: P,
-        default_meta: serde_json::Value
+        default_meta: Map<String, Value>
     ) -> Result<SoupContexts, SouperIoError> {
         let mut soup_contexts: BTreeMap<String, BTreeSet<Soup>> = BTreeMap::new();
         for path in paths {

--- a/src/soup/contexts_io.rs
+++ b/src/soup/contexts_io.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{BufReader, Write};
 use std::path::{Path, PathBuf};
+use serde_json;
 
 use crate::soup::model::{Soup, SoupContexts, SouperIoError};
 use crate::parse::{
@@ -16,6 +17,7 @@ impl SoupContexts {
     pub fn from_paths<P: AsRef<Path>>(
         paths: Vec<PathBuf>,
         source_dir: P,
+        default_meta: serde_json::Value
     ) -> Result<SoupContexts, SouperIoError> {
         let mut soup_contexts: BTreeMap<String, BTreeSet<Soup>> = BTreeMap::new();
         for path in paths {
@@ -35,9 +37,9 @@ impl SoupContexts {
                 }
             };
             let parse_result = match filename.to_str() {
-                    Some("package.json") => PackageJson::soups(reader),
-                    Some(x) if x.contains(".csproj") => CsProj::soups(reader),
-                    Some(x) if x.contains("Dockerfile") => DockerBase::soups(reader),
+                    Some("package.json") => PackageJson::soups(reader, &default_meta),
+                    Some(x) if x.contains(".csproj") => CsProj::soups(reader, &default_meta),
+                    Some(x) if x.contains("Dockerfile") => DockerBase::soups(reader, &default_meta),
                     _ => {
                         panic!("No parser found for: {:?}", filename)
                     }

--- a/src/soup/model.rs
+++ b/src/soup/model.rs
@@ -9,13 +9,16 @@ use serde::{
     Deserialize,
     Serialize
 };
-use serde_json;
+use serde_json::{
+    Map,
+    Value
+};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Soup {
     pub name: String,
     pub version: String,
-    pub meta: serde_json::Value
+    pub meta: Map<String, Value>
 }
 
 impl PartialEq for Soup {
@@ -93,12 +96,12 @@ mod tests {
         let s1 = Soup{
             name: "some-dependency".to_owned(),
             version: "1.0.0".to_owned(),
-            meta: json!({})
+            meta: Map::new()
         };
         let s2 = Soup{
             name: "some-dependency".to_owned(),
             version: "1.0.0".to_owned(),
-            meta: json!("{\"requirement\": \"should do this and that\"}")
+            meta: json!({"requirement": "should do this and that"}).as_object().unwrap().clone()
         };
         assert_eq!(s1, s2);
     }
@@ -108,12 +111,12 @@ mod tests {
         let s1 = Soup{
             name: "some-dependency".to_owned(),
             version: "1.0.0".to_owned(),
-            meta: json!({})
+            meta: Map::new()
         };
         let s2 = Soup{
             name: "some-dependency".to_owned(),
             version: "1.0.1".to_owned(),
-            meta: json!({})
+            meta: Map::new()
         };
         assert_ne!(s1, s2);
     }


### PR DESCRIPTION
Add support for --meta-key argument. The value of each --meta-key argument will be set as a key in meta property.
Additionally:
 - Changed type for meta from Value to Map<String, Value>, which enforces it to be a json object (where each key can have a value with arbitrary json)
 - Enable preserve_order feature in serde_json, which will preserve order to the properties in meta object
   - Previously those would be sorted alphabetically