### PR TITLE
Add support for multiple parsers for one type of file

### DIFF
--- a/src/dir_scan.rs
+++ b/src/dir_scan.rs
@@ -20,7 +20,7 @@ const GLOBAL_EXCLUDE_DIRS: [&str; 3] = [
     "obj"
 ];
 
-pub fn scan2(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf, Vec<Box<dyn SoupParse>>)>, Error>{
+pub fn scan(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf, Vec<Box<dyn SoupParse>>)>, Error>{
     let mut sources: Vec<(PathBuf, Vec<Box<dyn SoupParse>>)> = Vec::new();
     'entries: for entry in fs::read_dir(dir)? {
         let entry = entry?;
@@ -38,7 +38,7 @@ pub fn scan2(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf,
                     continue 'entries;
                 }
             }
-            let mut content = scan2(&path, exclude_dirs)?;
+            let mut content = scan(&path, exclude_dirs)?;
             sources.append(&mut content);
             continue;
         }

--- a/src/dir_scan.rs
+++ b/src/dir_scan.rs
@@ -8,7 +8,7 @@ use std::{
     }
 };
 use crate::parse::{
-    SoupSource,
+    SoupParse,
     package_json::PackageJson,
     csproj::CsProj,
     docker_base::DockerBase
@@ -20,8 +20,8 @@ const GLOBAL_EXCLUDE_DIRS: [&str; 3] = [
     "obj"
 ];
 
-pub fn scan2(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf, Vec<Box<dyn SoupSource>>)>, Error>{
-    let mut sources: Vec<(PathBuf, Vec<Box<dyn SoupSource>>)> = Vec::new();
+pub fn scan2(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf, Vec<Box<dyn SoupParse>>)>, Error>{
+    let mut sources: Vec<(PathBuf, Vec<Box<dyn SoupParse>>)> = Vec::new();
     'entries: for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -60,42 +60,3 @@ pub fn scan2(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf,
     Ok(sources)
 }
 
-pub fn scan(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<PathBuf>, Error> {
-    let mut files: Vec<PathBuf> = Vec::new();
-    'entries: for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let file_type = entry.file_type()?;
-        let file_name = entry.file_name();
-        if file_type.is_dir() {
-            for ex in GLOBAL_EXCLUDE_DIRS {
-                if file_name.eq(ex) {
-                    continue 'entries;
-                }
-            }
-            for ex in exclude_dirs {
-                if path.eq(ex) {
-                    continue 'entries;
-                }
-            }
-            let mut content = scan(&path, exclude_dirs)?;
-            files.append(&mut content);
-            continue;
-        }
-        if file_type.is_file() {
-            match file_name.to_str() {
-                Some("package.json") => {
-                    files.push(path);
-                },
-                Some(file_name_str) if file_name_str.contains(".csproj") => {
-                    files.push(path);
-                },
-                Some(file_name_str) if file_name_str.contains("Dockerfile") => {
-                    files.push(path);
-                },
-                _ => {}
-            }
-        }
-    }
-    Ok(files)
-}

--- a/src/dir_scan.rs
+++ b/src/dir_scan.rs
@@ -7,7 +7,12 @@ use std::{
         PathBuf
     }
 };
-use crate::parse::SoupSource;
+use crate::parse::{
+    SoupSource,
+    package_json::PackageJson,
+    csproj::CsProj,
+    docker_base::DockerBase
+};
 
 const GLOBAL_EXCLUDE_DIRS: [&str; 3] = [
     "node_modules",
@@ -15,9 +20,45 @@ const GLOBAL_EXCLUDE_DIRS: [&str; 3] = [
     "obj"
 ];
 
-// pub fn scan(dir: PathBuf, exclude_dirs: Vec<PathBuf>) -> Result<Vec<(PathBuf, Box<dyn SoupSource>)>, Error>{
-
-// }
+pub fn scan2(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf, Vec<Box<dyn SoupSource>>)>, Error>{
+    let mut sources: Vec<(PathBuf, Vec<Box<dyn SoupSource>>)> = Vec::new();
+    'entries: for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        let file_name = entry.file_name();
+        if file_type.is_dir() {
+            for ex in GLOBAL_EXCLUDE_DIRS {
+                if file_name.eq(ex) {
+                    continue 'entries;
+                }
+            }
+            for ex in exclude_dirs {
+                if path.eq(ex) {
+                    continue 'entries;
+                }
+            }
+            let mut content = scan2(&path, exclude_dirs)?;
+            sources.append(&mut content);
+            continue;
+        }
+        if file_type.is_file() {
+            match file_name.to_str() {
+                Some("package.json") => {
+                    sources.push((path, vec![Box::new(PackageJson{})]));
+                },
+                Some(file_name_str) if file_name_str.contains(".csproj") => {
+                    sources.push((path, vec![Box::new(CsProj{})]));
+                },
+                Some(file_name_str) if file_name_str.contains("Dockerfile") => {
+                    sources.push((path, vec![Box::new(DockerBase{})]));
+                },
+                _ => {}
+            }
+        }
+    }
+    Ok(sources)
+}
 
 pub fn scan(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<PathBuf>, Error> {
     let mut files: Vec<PathBuf> = Vec::new();

--- a/src/dir_scan.rs
+++ b/src/dir_scan.rs
@@ -1,4 +1,13 @@
-use std::{fs, io, path};
+use std::{
+    fs,
+    io::{
+        Error
+    },
+    path::{
+        PathBuf
+    }
+};
+use crate::parse::SoupSource;
 
 const GLOBAL_EXCLUDE_DIRS: [&str; 3] = [
     "node_modules",
@@ -6,8 +15,12 @@ const GLOBAL_EXCLUDE_DIRS: [&str; 3] = [
     "obj"
 ];
 
-pub fn scan(dir: &path::PathBuf, exclude_dirs: &Vec<path::PathBuf>) -> Result<Vec<path::PathBuf>, io::Error> {
-    let mut files: Vec<path::PathBuf> = Vec::new();
+// pub fn scan(dir: PathBuf, exclude_dirs: Vec<PathBuf>) -> Result<Vec<(PathBuf, Box<dyn SoupSource>)>, Error>{
+
+// }
+
+pub fn scan(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<PathBuf>, Error> {
+    let mut files: Vec<PathBuf> = Vec::new();
     'entries: for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();

--- a/src/dir_scan.rs
+++ b/src/dir_scan.rs
@@ -29,12 +29,12 @@ pub fn scan(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf, 
         let file_name = entry.file_name();
         if file_type.is_dir() {
             for ex in GLOBAL_EXCLUDE_DIRS {
-                if file_name.eq(ex) {
+                if file_name == ex {
                     continue 'entries;
                 }
             }
             for ex in exclude_dirs {
-                if path.eq(ex) {
+                if path == *ex {
                     continue 'entries;
                 }
             }

--- a/src/dir_scan.rs
+++ b/src/dir_scan.rs
@@ -20,7 +20,9 @@ const GLOBAL_EXCLUDE_DIRS: [&str; 3] = [
     "obj"
 ];
 
-pub fn scan(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf, Vec<Box<dyn SoupParse>>)>, Error>{
+pub type SoupParsers = Vec<Box<dyn SoupParse>>;
+
+pub fn scan(dir: &PathBuf, exclude_dirs: &Vec<PathBuf>) -> Result<Vec<(PathBuf, SoupParsers)>, Error>{
     let mut sources: Vec<(PathBuf, Vec<Box<dyn SoupParse>>)> = Vec::new();
     'entries: for entry in fs::read_dir(dir)? {
         let entry = entry?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
         }
         false => SoupContexts::empty()
     };
-    let result = match dir_scan::scan2(&target_dir, &exclude_dirs) {
+    let result = match dir_scan::scan(&target_dir, &exclude_dirs) {
         Ok(result) => result,
         Err(e) => {
             panic!("{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
         }
         false => SoupContexts::empty()
     };
-    let result = match dir_scan::scan(&target_dir, &exclude_dirs) {
+    let result = match dir_scan::scan2(&target_dir, &exclude_dirs) {
         Ok(result) => result,
         Err(e) => {
             panic!("{}", e);

--- a/src/parse/csproj.rs
+++ b/src/parse/csproj.rs
@@ -7,12 +7,12 @@ use serde_json::{
 };
 use quick_xml::events::Event;
 use quick_xml::Reader;
-use super::SoupSource;
+use super::SoupParse;
 use crate::soup::model::{Soup, SoupSourceParseError};
 
 pub struct CsProj {}
 
-impl SoupSource for CsProj {
+impl SoupParse for CsProj {
     fn soups(&self, content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
         let mut reader = Reader::from_str(content);
         reader.trim_text(true);

--- a/src/parse/csproj.rs
+++ b/src/parse/csproj.rs
@@ -1,6 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap},
-    io
+    collections::{BTreeSet, HashMap}
 };
 use serde_json::{
     Map,
@@ -13,12 +12,9 @@ use crate::soup::model::{Soup, SoupSourceParseError};
 
 pub struct CsProj {}
 
-impl<R> SoupSource<R> for CsProj
-where
-    R: io::BufRead,
-{
-    fn soups(reader: R, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
-        let mut reader = Reader::from_reader(reader);
+impl SoupSource for CsProj {
+    fn soups(content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
+        let mut reader = Reader::from_str(content);
         reader.trim_text(true);
         reader.expand_empty_elements(true);
 
@@ -83,7 +79,7 @@ mod tests {
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.2.1" />
     </ItemGroup>
 </Project>
-        "#.as_bytes();
+        "#;
 
         let result = CsProj::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
@@ -106,7 +102,7 @@ mod tests {
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     </ItemGroup>
 </Project>
-        "#.as_bytes();
+        "#;
 
         let result = CsProj::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
@@ -126,7 +122,7 @@ mod tests {
     <ItemGroup>
     </ItemGroup>
 </Project>
-        "#.as_bytes();
+        "#;
 
         let result = CsProj::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());

--- a/src/parse/csproj.rs
+++ b/src/parse/csproj.rs
@@ -13,7 +13,7 @@ use crate::soup::model::{Soup, SoupSourceParseError};
 pub struct CsProj {}
 
 impl SoupSource for CsProj {
-    fn soups(content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
+    fn soups(&self, content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
         let mut reader = Reader::from_str(content);
         reader.trim_text(true);
         reader.expand_empty_elements(true);
@@ -81,7 +81,7 @@ mod tests {
 </Project>
         "#;
 
-        let result = CsProj::soups(content, &Map::new());
+        let result = CsProj{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(1, soups.len());
@@ -104,7 +104,7 @@ mod tests {
 </Project>
         "#;
 
-        let result = CsProj::soups(content, &Map::new());
+        let result = CsProj{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(2, soups.len());
@@ -124,7 +124,7 @@ mod tests {
 </Project>
         "#;
 
-        let result = CsProj::soups(content, &Map::new());
+        let result = CsProj{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(0, soups.len());

--- a/src/parse/docker_base.rs
+++ b/src/parse/docker_base.rs
@@ -17,7 +17,7 @@ lazy_static! {
 }
 
 impl SoupSource for DockerBase {
-    fn soups(content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
+    fn soups(&self, content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
         let mut result: BTreeSet<Soup> = BTreeSet::new();
         let lines = content.lines();
         for line in lines {
@@ -45,7 +45,7 @@ mod tests {
 FROM postgres:14.4
         "#;
 
-        let result = DockerBase::soups(content, &Map::new());
+        let result = DockerBase{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         let expected_soup = Soup {
@@ -62,7 +62,7 @@ FROM postgres:14.4
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
         "#;
 
-        let result = DockerBase::soups(content, &Map::new());
+        let result = DockerBase{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         let expected_soup = Soup {
@@ -79,7 +79,7 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
         "#;
 
-        let result = DockerBase::soups(content, &Map::new());
+        let result = DockerBase{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         let expected_soup = Soup{
@@ -95,7 +95,7 @@ FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
         let content = r#"
 COPY --chown app:app . ./
         "#;
-        let result = DockerBase::soups(content, &Map::new());
+        let result = DockerBase{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(0, soups.len());

--- a/src/parse/docker_base.rs
+++ b/src/parse/docker_base.rs
@@ -7,7 +7,7 @@ use serde_json::{
 };
 use regex::Regex;
 use lazy_static::lazy_static;
-use super::SoupSource;
+use super::SoupParse;
 use crate::soup::model::{Soup, SoupSourceParseError};
 
 pub struct DockerBase {}
@@ -16,7 +16,7 @@ lazy_static! {
     static ref BASE_PATTERN: Regex = Regex::new(r"^ *FROM +(?:--platform=[\w/]+ +)?(?P<name>[\w\-\./]+):(?P<version>[\w\.-]+) *(?:AS +[\w\-]+)? *$").unwrap();
 }
 
-impl SoupSource for DockerBase {
+impl SoupParse for DockerBase {
     fn soups(&self, content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
         let mut result: BTreeSet<Soup> = BTreeSet::new();
         let lines = content.lines();

--- a/src/parse/docker_base.rs
+++ b/src/parse/docker_base.rs
@@ -1,6 +1,5 @@
 use std::{
-    collections::BTreeSet,
-    io
+    collections::BTreeSet
 };
 use serde_json::{
     Map,
@@ -17,28 +16,22 @@ lazy_static! {
     static ref BASE_PATTERN: Regex = Regex::new(r"^ *FROM +(?:--platform=[\w/]+ +)?(?P<name>[\w\-\./]+):(?P<version>[\w\.-]+) *(?:AS +[\w\-]+)? *$").unwrap();
 }
 
-impl<R> SoupSource<R> for DockerBase
-where
-    R: io::BufRead,
-{
-    fn soups(reader: R, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
-        Ok(reader.lines()
-            .filter_map(|line| line.ok())
-            .filter_map(|line| {
-                match BASE_PATTERN.captures(&line) {
-                    Some(captures) => {
-                        let name = captures.name("name").unwrap().as_str();
-                        let version = captures.name("version").unwrap().as_str();
-                        Some(Soup{
-                            name: name.to_owned(),
-                            version: version.to_owned(),
-                            meta: default_meta.clone()
-                        })
-                    },
-                    None => None
-                }
-            })
-            .collect::<BTreeSet<Soup>>())
+impl SoupSource for DockerBase {
+    fn soups(content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
+        let mut result: BTreeSet<Soup> = BTreeSet::new();
+        let lines = content.lines();
+        for line in lines {
+            if let Some(captures) = BASE_PATTERN.captures(line) {
+                let name = captures.name("name").unwrap().as_str();
+                let version = captures.name("version").unwrap().as_str();
+                result.insert(Soup{
+                    name: name.to_owned(),
+                    version: version.to_owned(),
+                    meta: default_meta.clone()
+                });
+            }
+        }
+        Ok(result)
     }
 }
 
@@ -50,7 +43,7 @@ mod tests {
     fn simple_base() {
         let content = r#"
 FROM postgres:14.4
-        "#.as_bytes();
+        "#;
 
         let result = DockerBase::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
@@ -67,7 +60,7 @@ FROM postgres:14.4
     fn named_base() {
         let content = r#"
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
-        "#.as_bytes();
+        "#;
 
         let result = DockerBase::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
@@ -84,7 +77,7 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
     fn with_platform() {
         let content = r#"
 FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
-        "#.as_bytes();
+        "#;
 
         let result = DockerBase::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
@@ -101,7 +94,7 @@ FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
     fn no_from_statement() {
         let content = r#"
 COPY --chown app:app . ./
-        "#.as_bytes();
+        "#;
         let result = DockerBase::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -6,7 +6,7 @@ use serde_json::{
 use crate::soup::model::{Soup, SoupSourceParseError};
 
 pub trait SoupSource {
-    fn soups(content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
+    fn soups(&self, content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
 }
 
 pub mod package_json;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,13 +1,12 @@
 use std::collections::BTreeSet;
-use std::io;
 use serde_json::{
     Map,
     Value
 };
 use crate::soup::model::{Soup, SoupSourceParseError};
 
-pub trait SoupSource<R: io::BufRead> {
-    fn soups(reader: R, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
+pub trait SoupSource {
+    fn soups(content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
 }
 
 pub mod package_json;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -5,7 +5,7 @@ use serde_json::{
 };
 use crate::soup::model::{Soup, SoupSourceParseError};
 
-pub trait SoupSource {
+pub trait SoupParse {
     fn soups(&self, content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError>;
 }
 

--- a/src/parse/package_json.rs
+++ b/src/parse/package_json.rs
@@ -7,7 +7,7 @@ use serde_json::{
 };
 use serde::Deserialize;
 use crate::soup::model::{Soup, SoupSourceParseError};
-use super::SoupSource;
+use super::SoupParse;
 
 pub struct PackageJson {}
 
@@ -16,7 +16,7 @@ struct Content {
     dependencies: HashMap<String, String>
 }
 
-impl SoupSource for PackageJson {
+impl SoupParse for PackageJson {
     fn soups(&self, content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
         let content: Content = match serde_json::from_str(content) {
             Ok(content) => content,

--- a/src/parse/package_json.rs
+++ b/src/parse/package_json.rs
@@ -17,7 +17,7 @@ struct Content {
 }
 
 impl SoupSource for PackageJson {
-    fn soups(content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
+    fn soups(&self, content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
         let content: Content = match serde_json::from_str(content) {
             Ok(content) => content,
             Err(e) => {
@@ -48,7 +48,7 @@ mod tests {
                 "some-lib": "^1.0.0"
             }
         }"#;
-        let result = PackageJson::soups(content, &Map::new());
+        let result = PackageJson{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(1, soups.len());
@@ -68,7 +68,7 @@ mod tests {
                 "another-lib": "6.6.6"
             }
         }"#;
-        let result = PackageJson::soups(content, &Map::new());
+        let result = PackageJson{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(2, soups.len());
@@ -84,7 +84,7 @@ mod tests {
         let content = r#"{
             "dependencies": {}
         }"#;
-        let result = PackageJson::soups(content, &Map::new());
+        let result = PackageJson{}.soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
         assert_eq!(0, soups.len());

--- a/src/parse/package_json.rs
+++ b/src/parse/package_json.rs
@@ -1,6 +1,5 @@
 use std::{
-    collections::{HashMap, BTreeSet},
-    io,
+    collections::{HashMap, BTreeSet}
 };
 use serde_json::{
     Map,
@@ -17,9 +16,9 @@ struct Content {
     dependencies: HashMap<String, String>
 }
 
-impl <R> SoupSource<R> for PackageJson where R: io::BufRead {
-    fn soups(reader: R, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
-        let content: Content = match serde_json::from_reader(reader) {
+impl SoupSource for PackageJson {
+    fn soups(content: &str, default_meta: &Map<String, Value>) -> Result<BTreeSet<Soup>, SoupSourceParseError> {
+        let content: Content = match serde_json::from_str(content) {
             Ok(content) => content,
             Err(e) => {
                 return Err(SoupSourceParseError{
@@ -48,7 +47,7 @@ mod tests {
             "dependencies": {
                 "some-lib": "^1.0.0"
             }
-        }"#.as_bytes();
+        }"#;
         let result = PackageJson::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
@@ -68,7 +67,7 @@ mod tests {
                 "some-lib": "^1.0.0",
                 "another-lib": "6.6.6"
             }
-        }"#.as_bytes();
+        }"#;
         let result = PackageJson::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();
@@ -84,7 +83,7 @@ mod tests {
     fn no_dependencies() {
         let content = r#"{
             "dependencies": {}
-        }"#.as_bytes();
+        }"#;
         let result = PackageJson::soups(content, &Map::new());
         assert_eq!(true, result.is_ok());
         let soups = result.unwrap();

--- a/src/soup/contexts_apply.rs
+++ b/src/soup/contexts_apply.rs
@@ -41,8 +41,8 @@ fn combine_soups(base: BTreeSet<Soup>, other: BTreeSet<Soup>) -> BTreeSet<Soup> 
         .collect::<BTreeSet<Soup>>()
 }
 
-fn combine_meta(mut base: Map<String, Value>, patch: Map<String, Value>) -> Map<String, Value> {
-    let mut patch = patch.into_iter().collect::<Vec<(String, Value)>>();
+fn combine_meta(mut base: Map<String, Value>, other: Map<String, Value>) -> Map<String, Value> {
+    let mut patch = other.into_iter().collect::<Vec<(String, Value)>>();
     while let Some((key, value)) = patch.pop() {
         if let serde_json::map::Entry::Vacant(entry) = base.entry(key) {
             entry.insert(value);

--- a/src/soup/contexts_io.rs
+++ b/src/soup/contexts_io.rs
@@ -1,64 +1,43 @@
+use serde_json::{Map, Value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{BufReader, Write};
 use std::path::{Path, PathBuf};
-use serde_json::{
-    Map,
-    Value
-};
 
+use crate::parse::SoupParse;
 use crate::soup::model::{Soup, SoupContexts, SouperIoError};
-use crate::parse::{
-    SoupParse,
-};
 use crate::utils;
 
 impl SoupContexts {
     pub fn from_paths<P: AsRef<Path>>(
         paths: Vec<(PathBuf, Vec<Box<dyn SoupParse>>)>,
         source_dir: P,
-        default_meta: Map<String, Value>
+        default_meta: Map<String, Value>,
     ) -> Result<SoupContexts, SouperIoError> {
         let mut soup_contexts: BTreeMap<String, BTreeSet<Soup>> = BTreeMap::new();
         for (path, parsers) in paths {
             let file_content = match fs::read_to_string(&path) {
                 Ok(content) => content,
-                Err(e) => return Err(SouperIoError{
-                    message: format!("Not able to read file: {} ({})", path.display(), e)
-                })
-            };
-            let parse_results: Result<Vec<_>, _> = parsers.into_iter()
-                .map(|y| y.soups(&file_content, &default_meta))
-                .collect();
-            let soups = match parse_results {
-                Ok(soups_iter) => soups_iter.into_iter()
-                    .flatten()
-                    .collect(),
                 Err(e) => {
                     return Err(SouperIoError {
-                        message: format!("Unable to parse {} due to: {}", path.display(), e)
-                    });
-                }
-            };
-            let relative_path = match utils::relative_path(path.as_ref(), source_dir.as_ref()) {
-                Ok(relative_path) => relative_path,
-                Err(_e) => {
-                    return Err(SouperIoError {
-                        message: format!("Not able to obtain relative path for: {} (from {})", path.display(), source_dir.as_ref().display())
-                    });
-                }
-            };
-            let relative_path = relative_path.into_os_string();
-            let relative_path = match relative_path.into_string() {
-                Ok(path_string) => path_string,
-                Err(_) => {
-                    return Err(SouperIoError{
-                        message: "Not able to convert relative path to string".to_string()
+                        message: format!("Not able to read file: {} ({})", path.display(), e),
                     })
                 }
             };
-            let relative_path = relative_path.replace('\\', "/");
-            soup_contexts.insert(relative_path, soups);
+            let parse_results: Result<Vec<_>, _> = parsers
+                .into_iter()
+                .map(|y| y.soups(&file_content, &default_meta))
+                .collect();
+            let soups = match parse_results {
+                Ok(soups_iter) => soups_iter.into_iter().flatten().collect(),
+                Err(e) => {
+                    return Err(SouperIoError {
+                        message: format!("Unable to parse {} due to: {}", path.display(), e),
+                    });
+                }
+            };
+            let context_path = relative_path(path.as_ref(), source_dir.as_ref())?;
+            soup_contexts.insert(context_path, soups);
         }
         Ok(SoupContexts {
             contexts: soup_contexts,
@@ -69,8 +48,12 @@ impl SoupContexts {
         let output_file = match fs::File::open(file_path.as_ref()) {
             Ok(file) => file,
             Err(e) => {
-                return Err(SouperIoError{
-                    message: format!("Not able to open file: {} ({})", file_path.as_ref().display(), e)
+                return Err(SouperIoError {
+                    message: format!(
+                        "Not able to open file: {} ({})",
+                        file_path.as_ref().display(),
+                        e
+                    ),
                 });
             }
         };
@@ -78,8 +61,12 @@ impl SoupContexts {
         let contexts: BTreeMap<String, BTreeSet<Soup>> = match serde_json::from_reader(reader) {
             Ok(contexts) => contexts,
             Err(e) => {
-                return Err(SouperIoError{
-                    message: format!("Not able to parse file: {} ({})", file_path.as_ref().display(), e)
+                return Err(SouperIoError {
+                    message: format!(
+                        "Not able to parse file: {} ({})",
+                        file_path.as_ref().display(),
+                        e
+                    ),
                 });
             }
         };
@@ -89,21 +76,60 @@ impl SoupContexts {
     pub fn write_to_file<P: AsRef<Path>>(&self, file_path: P) -> Result<(), SouperIoError> {
         let mut output_file = match fs::File::create(&file_path) {
             Ok(file) => file,
-            Err(e) => return Err(SouperIoError{
-                message: format!("Not able to create file: {} ({})", file_path.as_ref().display(), e)
-            })
+            Err(e) => {
+                return Err(SouperIoError {
+                    message: format!(
+                        "Not able to create file: {} ({})",
+                        file_path.as_ref().display(),
+                        e
+                    ),
+                })
+            }
         };
         let json = match serde_json::to_string_pretty(&self.contexts()) {
             Ok(json) => json,
-            Err(e) => return Err(SouperIoError{
-                message: format!("Not able to serialize to json: {}", e)
-            })
+            Err(e) => {
+                return Err(SouperIoError {
+                    message: format!("Not able to serialize to json: {}", e),
+                })
+            }
         };
         match output_file.write_all(json.as_bytes()) {
             Ok(_x) => Ok(()),
-            Err(e) => return Err(SouperIoError{
-                message: format!("Not able to write to file: {} ({})", file_path.as_ref().display(), e)
-            }),
+            Err(e) => {
+                return Err(SouperIoError {
+                    message: format!(
+                        "Not able to write to file: {} ({})",
+                        file_path.as_ref().display(),
+                        e
+                    ),
+                })
+            }
         }
     }
+}
+
+fn relative_path<P: AsRef<Path>>(full_path: P, root_path: P) -> Result<String, SouperIoError> {
+    let relative_path = match utils::relative_path(full_path.as_ref(), root_path.as_ref()) {
+        Ok(relative_path) => relative_path,
+        Err(_e) => {
+            return Err(SouperIoError {
+                message: format!(
+                    "Not able to obtain relative path for: {} (from {})",
+                    full_path.as_ref().display(),
+                    root_path.as_ref().display()
+                ),
+            });
+        }
+    };
+    let relative_path = match relative_path.into_os_string().into_string() {
+        Ok(path_string) => path_string,
+        Err(_) => {
+            return Err(SouperIoError {
+                message: "Not able to convert relative path to string".to_string(),
+            })
+        }
+    };
+    let relative_path = relative_path.replace('\\', "/");
+    Ok(relative_path)
 }

--- a/src/soup/contexts_io.rs
+++ b/src/soup/contexts_io.rs
@@ -39,9 +39,9 @@ impl SoupContexts {
                 }
             };
             let parse_result = match filename.to_str() {
-                    Some("package.json") => PackageJson::soups(&file_content, &default_meta),
-                    Some(x) if x.contains(".csproj") => CsProj::soups(&file_content, &default_meta),
-                    Some(x) if x.contains("Dockerfile") => DockerBase::soups(&file_content, &default_meta),
+                    Some("package.json") => PackageJson{}.soups(&file_content, &default_meta),
+                    Some(x) if x.contains(".csproj") => CsProj{}.soups(&file_content, &default_meta),
+                    Some(x) if x.contains("Dockerfile") => DockerBase{}.soups(&file_content, &default_meta),
                     _ => {
                         panic!("No parser found for: {:?}", filename)
                     }


### PR DESCRIPTION
Could be needed to e.g. identify soups in bash scripts.