### PR TITLE
Don't set explicit release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - uses: softprops/action-gh-release@v1
         with:
-          name: ${{ github.ref }}
           generate_release_notes: true
 
   release-build:


### PR DESCRIPTION
Since github.ref will return e.g. refs/tags/vX.X.X